### PR TITLE
Binary_size_bench: Fix file not found error

### DIFF
--- a/collector/src/benchmark/benchmark.rs
+++ b/collector/src/benchmark/benchmark.rs
@@ -547,6 +547,7 @@ pub struct BenchmarkConfig {
     pub runtime_test_type: Option<RuntimeTestType>,
     pub example_lst: Option<Vec<String>>,
     pub runtime_args: Option<String>,
+    pub target_path: Option<PathBuf>,
     /// The file that should be touched to ensure cargo re-checks the leaf crate
     /// we're interested in. Likely, something similar to `src/lib.rs`. The
     /// default if this is not present is to touch all .rs files in the

--- a/collector/src/compile_time/binary_size/binary_package_process.rs
+++ b/collector/src/compile_time/binary_size/binary_package_process.rs
@@ -19,6 +19,7 @@ pub struct BinaryPackageProcess<'a> {
     pub rustc_args: Vec<String>,
     pub touch_file: Option<String>,
     pub packages: Vec<String>,
+    pub target_path: Option<PathBuf>,
 }
 
 impl<'a> BinaryProcess for BinaryPackageProcess<'a> {
@@ -32,11 +33,20 @@ impl<'a> BinaryProcess for BinaryPackageProcess<'a> {
                 .arg("rustc")
                 .arg("--manifest-path")
                 .arg(&self.manifest_path)
-                .arg("--profile")
-                .arg(self.profile.to_string())
                 .arg("--package")
                 .arg(package)
                 .args(&self.cargo_args);
+
+            match self.profile {
+                Profile::Check => {
+                    cmd.arg("--profile").arg("check");
+                }
+                Profile::Debug => (),
+                Profile::Doc => unimplemented!(),
+                Profile::Release => {
+                    cmd.arg("--release");
+                }
+            }
 
             cmd.stdout(Stdio::null()).stderr(Stdio::null());
 
@@ -47,17 +57,17 @@ impl<'a> BinaryProcess for BinaryPackageProcess<'a> {
 
         let mut binary_size = 0;
 
-        let mut target_dir = PathBuf::from(self.cwd);
-        if self.manifest_path.contains('/') {
-            let segment = self.manifest_path.split('/');
-            let toml = segment.clone().last().unwrap();
-            segment.for_each(|s| {
-                if s != toml {
-                    target_dir = target_dir.join(s);
-                }
-            });
-        }
-        target_dir = target_dir.join("target").join(self.profile.to_string());
+        
+        let target_dir = if let Some(target_path) = &self.target_path {
+            PathBuf::from(self.cwd)
+            .join(target_path)
+            .join("target")
+            .join(self.profile.to_string())
+        } else {
+            PathBuf::from(self.cwd)
+            .join("target")
+            .join(self.profile.to_string())
+        };
 
         let dir = read_dir(target_dir)?;
         for entry in dir {

--- a/collector/src/compile_time/binary_size/binary_package_process.rs
+++ b/collector/src/compile_time/binary_size/binary_package_process.rs
@@ -57,16 +57,15 @@ impl<'a> BinaryProcess for BinaryPackageProcess<'a> {
 
         let mut binary_size = 0;
 
-        
         let target_dir = if let Some(target_path) = &self.target_path {
             PathBuf::from(self.cwd)
-            .join(target_path)
-            .join("target")
-            .join(self.profile.to_string())
+                .join(target_path)
+                .join("target")
+                .join(self.profile.to_string())
         } else {
             PathBuf::from(self.cwd)
-            .join("target")
-            .join(self.profile.to_string())
+                .join("target")
+                .join(self.profile.to_string())
         };
 
         let dir = read_dir(target_dir)?;

--- a/collector/src/compile_time/binary_size/binary_single_process.rs
+++ b/collector/src/compile_time/binary_size/binary_single_process.rs
@@ -53,13 +53,13 @@ impl<'a> BinaryProcess for BinarySingleProcess<'a> {
 
         let target_dir = if let Some(target_path) = &self.target_path {
             PathBuf::from(self.cwd)
-            .join(target_path)
-            .join("target")
-            .join(self.profile.to_string())
+                .join(target_path)
+                .join("target")
+                .join(self.profile.to_string())
         } else {
             PathBuf::from(self.cwd)
-            .join("target")
-            .join(self.profile.to_string())
+                .join("target")
+                .join(self.profile.to_string())
         };
 
         let mut binary_size = 0;

--- a/collector/src/compile_time/binary_size/binary_single_process.rs
+++ b/collector/src/compile_time/binary_size/binary_single_process.rs
@@ -18,11 +18,13 @@ pub struct BinarySingleProcess<'a> {
     pub cargo_args: Vec<String>,
     pub rustc_args: Vec<String>,
     pub touch_file: Option<String>,
+    pub target_path: Option<PathBuf>,
 }
 
 impl<'a> BinaryProcess for BinarySingleProcess<'a> {
     fn run_rustc(&self) -> anyhow::Result<Option<Stats>> {
         let mut cmd = Command::new(Path::new(self.compiler.cargo));
+
         cmd.current_dir(self.cwd)
             .env("RUSTC", &*self.compiler.rustc)
             .env("CARGO_INCREMENTAL", "0")
@@ -30,9 +32,18 @@ impl<'a> BinaryProcess for BinarySingleProcess<'a> {
             .arg("rustc")
             .arg("--manifest-path")
             .arg(&self.manifest_path)
-            .arg("--profile")
-            .arg(self.profile.to_string())
             .args(&self.cargo_args);
+
+        match self.profile {
+            Profile::Check => {
+                cmd.arg("--profile").arg("check");
+            }
+            Profile::Debug => (),
+            Profile::Doc => unimplemented!(),
+            Profile::Release => {
+                cmd.arg("--release");
+            }
+        }
 
         cmd.stdout(Stdio::null()).stderr(Stdio::null());
 
@@ -40,17 +51,16 @@ impl<'a> BinaryProcess for BinarySingleProcess<'a> {
             .wait()
             .expect(format!("Fail to compile {}.", self.processor_name).as_str());
 
-        let mut target_dir = PathBuf::from(self.cwd);
-        if self.manifest_path.contains('/') {
-            let segment = self.manifest_path.split('/');
-            let toml = segment.clone().last().unwrap();
-            segment.for_each(|s| {
-                if s != toml {
-                    target_dir = target_dir.join(s);
-                }
-            });
-        }
-        target_dir = target_dir.join("target").join(self.profile.to_string());
+        let target_dir = if let Some(target_path) = &self.target_path {
+            PathBuf::from(self.cwd)
+            .join(target_path)
+            .join("target")
+            .join(self.profile.to_string())
+        } else {
+            PathBuf::from(self.cwd)
+            .join("target")
+            .join(self.profile.to_string())
+        };
 
         let mut binary_size = 0;
         let dir = read_dir(target_dir)?;

--- a/collector/src/compile_time/binary_size/mod.rs
+++ b/collector/src/compile_time/binary_size/mod.rs
@@ -31,7 +31,14 @@ pub trait BinaryProcess {
     /// Files with ".d" suffix or directorys that are not relevant to the
     /// binary target should be filtered out.
     fn is_filtered_file_name(&self, file_name: OsString) -> bool {
-        let filted_names = vec!["build", "deps", "examples", "incremental"];
+        let filted_names = vec![
+            "build",
+            "deps",
+            "examples",
+            "incremental",
+            ".fingerprint",
+            ".cargo-lock",
+        ];
         if let Some(file_name) = file_name.to_str() {
             filted_names.contains(&file_name) | file_name.ends_with(".d")
         } else {
@@ -149,6 +156,7 @@ impl Benchamrk {
                     .map(String::from)
                     .collect(),
                 touch_file: self.config.touch_file.clone(),
+                target_path: self.config.target_path.clone(),
             }),
             CompileTimeType::Packages => Box::new(BinaryPackageProcess {
                 compiler,
@@ -180,6 +188,7 @@ impl Benchamrk {
                     .collect(),
                 touch_file: self.config.touch_file.clone(),
                 packages: self.config.packages.clone().unwrap(),
+                target_path: self.config.target_path.clone(),
             }),
         }
     }

--- a/collector/src/mir_analyze/mir_generate.rs
+++ b/collector/src/mir_analyze/mir_generate.rs
@@ -169,6 +169,7 @@ mod test {
                 touch_file: None,
                 disabled: false,
                 runs: 0,
+                target_path: None,
             },
         };
 


### PR DESCRIPTION
The position of `target` directory generated by rustc is not correctly handled in #19 . 